### PR TITLE
feat: Add p5.js canvases to HTML page

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ npm start
 ```
 
 The application will start on `http://localhost:3000`.
+
+## Viewing the Canvases
+
+Once the application is running, open your web browser and navigate to `http://localhost:3000/` to see the two canvases displayed side-by-side.

--- a/canvas1.js
+++ b/canvas1.js
@@ -1,107 +1,111 @@
-let nodes = [];
-const numNodes = 30; // Number of nodes in the graph
-let equilibriumX = []; // x positions when at rest
-let equilibriumY = []; // y positions when at rest
-let buttonState = false; // Tracks button state
+const sketch1 = (p) => {
+  let nodes = [];
+  const numNodes = 30; // Number of nodes in the graph
+  let equilibriumX = []; // x positions when at rest
+  let equilibriumY = []; // y positions when at rest
+  let buttonState = false; // Tracks button state
 
-function setup() {
-  createCanvas(400, 400);
-  // Initialize nodes with random positions
-  for (let i = 0; i < numNodes; i++) {
-    nodes.push({
-      x: random(width * 0.3, width * 0.7),
-      y: random(height * 0.3, height * 0.7),
-      vx: 0,
-      vy: 0,
-      mass: 1
-    });
-  }
-  setEquilibrium(); // Set starting equilibrium config
-}
+  p.setup = () => {
+    let canvas = p.createCanvas(400, 400);
+    canvas.parent('canvas1');
+    // Initialize nodes with random positions
+    for (let i = 0; i < numNodes; i++) {
+      nodes.push({
+        x: p.random(p.width * 0.3, p.width * 0.7),
+        y: p.random(p.height * 0.3, p.height * 0.7),
+        vx: 0,
+        vy: 0,
+        mass: 1
+      });
+    }
+    p.setEquilibrium(); // Set starting equilibrium config
+  };
 
-function draw() {
-  background(240); // Light gray background
+  p.draw = () => {
+    p.background(240); // Light gray background
 
-  // Draw the button outline
-  let buttonRadius = height * 0.4; // Radius of the button
-  fill(255);
-  stroke(200);
-  strokeWeight(2);
-  ellipse(width / 2, height / 2, buttonRadius * 2);
+    // Draw the button outline
+    let buttonRadius = p.height * 0.4; // Radius of the button
+    p.fill(255);
+    p.stroke(200);
+    p.strokeWeight(2);
+    p.ellipse(p.width / 2, p.height / 2, buttonRadius * 2);
 
-  // Apply force-directed layout
-  for (let i = 0; i < numNodes; i++) {
-    let node = nodes[i];
+    // Apply force-directed layout
+    for (let i = 0; i < numNodes; i++) {
+      let node = nodes[i];
 
-    // Attraction to equilibrium position
-    let dx = equilibriumX[i] - node.x;
-    let dy = equilibriumY[i] - node.y;
-    let forceX = dx * 0.05;
-    let forceY = dy * 0.05;
+      // Attraction to equilibrium position
+      let dx = equilibriumX[i] - node.x;
+      let dy = equilibriumY[i] - node.y;
+      let forceX = dx * 0.05;
+      let forceY = dy * 0.05;
 
-    // Repulsion from other nodes
-    for (let j = 0; j < numNodes; j++) {
-      if (i !== j) {
-        let other = nodes[j];
-        let distance = dist(node.x, node.y, other.x, other.y);
-        if (distance > 0 && distance < 50) { // Repulse only if close
-          let repelX = (node.x - other.x) / distance;
-          let repelY = (node.y - other.y) / distance;
-          forceX += repelX * 2;
-          forceY += repelY * 2;
+      // Repulsion from other nodes
+      for (let j = 0; j < numNodes; j++) {
+        if (i !== j) {
+          let other = nodes[j];
+          let distance = p.dist(node.x, node.y, other.x, other.y);
+          if (distance > 0 && distance < 50) { // Repulse only if close
+            let repelX = (node.x - other.x) / distance;
+            let repelY = (node.y - other.y) / distance;
+            forceX += repelX * 2;
+            forceY += repelY * 2;
+          }
         }
       }
-    }
 
-    // Damping and integration
-    node.vx = (node.vx + forceX / node.mass) * 0.8;
-    node.vy = (node.vy + forceY / node.mass) * 0.8;
-    node.x += node.vx;
-    node.y += node.vy;
+      // Damping and integration
+      node.vx = (node.vx + forceX / node.mass) * 0.8;
+      node.vy = (node.vy + forceY / node.mass) * 0.8;
+      node.x += node.vx;
+      node.y += node.vy;
 
-    // Keep nodes within button bounds
-    let distanceToCenter = dist(node.x, node.y, width / 2, height / 2);
-    if (distanceToCenter > buttonRadius) {
-      let angle = atan2(node.y - height / 2, node.x - width / 2);
-      node.x = width / 2 + cos(angle) * buttonRadius;
-      node.y = height / 2 + sin(angle) * buttonRadius;
-      node.vx = 0;
-      node.vy = 0;
-    }
+      // Keep nodes within button bounds
+      let distanceToCenter = p.dist(node.x, node.y, p.width / 2, p.height / 2);
+      if (distanceToCenter > buttonRadius) {
+        let angle = p.atan2(node.y - p.height / 2, node.x - p.width / 2);
+        node.x = p.width / 2 + p.cos(angle) * buttonRadius;
+        node.y = p.height / 2 + p.sin(angle) * buttonRadius;
+        node.vx = 0;
+        node.vy = 0;
+      }
 
-    // Draw nodes and connections
-    fill(0);
-    noStroke();
-    ellipse(node.x, node.y, 5);
-    for (let j = i + 1; j < numNodes; j++) {
-      stroke(100, 50);
-      line(node.x, node.y, nodes[j].x, nodes[j].y);
+      // Draw nodes and connections
+      p.fill(0);
+      p.noStroke();
+      p.ellipse(node.x, node.y, 5);
+      for (let j = i + 1; j < numNodes; j++) {
+        p.stroke(100, 50);
+        p.line(node.x, node.y, nodes[j].x, nodes[j].y);
+      }
     }
-  }
-}
+  };
 
-function mouseClicked() {
-  // Switch the button state
-  buttonState = !buttonState;
-  setEquilibrium();
-}
+  p.mouseClicked = () => {
+    // Switch the button state
+    buttonState = !buttonState;
+    p.setEquilibrium();
+  };
 
-function setEquilibrium() {
-  // Define equilibrium positions to resemble the shape of the logo
-  // These are rough approximations, adjust as needed
-  equilibriumX = [];
-  equilibriumY = [];
-  if (!buttonState) { // Button "off" state
-    for (let i = 0; i < numNodes; i++) {
-      let angle = map(i, 0, numNodes, 0, TWO_PI);
-      equilibriumX.push(width / 2 + cos(angle) * width * 0.15);
-      equilibriumY.push(height / 2 + sin(angle) * height * 0.15);
+  p.setEquilibrium = () => {
+    // Define equilibrium positions to resemble the shape of the logo
+    // These are rough approximations, adjust as needed
+    equilibriumX = [];
+    equilibriumY = [];
+    if (!buttonState) { // Button "off" state
+      for (let i = 0; i < numNodes; i++) {
+        let angle = p.map(i, 0, numNodes, 0, p.TWO_PI);
+        equilibriumX.push(p.width / 2 + p.cos(angle) * p.width * 0.15);
+        equilibriumY.push(p.height / 2 + p.sin(angle) * p.height * 0.15);
+      }
+    } else { // Button "on" state - different equilibrium
+      for (let i = 0; i < numNodes; i++) {
+        let angle = p.map(i, 0, numNodes, 0, p.TWO_PI);
+        equilibriumX.push(p.width / 2 + p.cos(angle * 2) * p.width * 0.2);
+        equilibriumY.push(p.height / 2 + p.sin(angle / 2) * p.height * 0.1);
+      }
     }
-  } else { // Button "on" state - different equilibrium
-    for (let i = 0; i < numNodes; i++) {
-      let angle = map(i, 0, numNodes, 0, TWO_PI);
-      equilibriumX.push(width / 2 + cos(angle * 2) * width * 0.2);
-      equilibriumY.push(height / 2 + sin(angle / 2) * height * 0.1);
-    }
-  }
-}
+  };
+};
+new p5(sketch1);

--- a/canvas2.js
+++ b/canvas2.js
@@ -1,72 +1,76 @@
-let particles = [];
-let sphereColor;
+const sketch2 = (p) => {
+  let particles = [];
+  let sphereColor;
 
-function setup() {
-  createCanvas(400, 400);
-  sphereColor = color(220); // Light gray for the sphere
-}
+  p.setup = () => {
+    let canvas = p.createCanvas(400, 400);
+    canvas.parent('canvas2');
+    sphereColor = p.color(220); // Light gray for the sphere
+  };
 
-function draw() {
-  background(240); // Slightly lighter background
+  p.draw = () => {
+    p.background(240); // Slightly lighter background
 
-  // Sphere with a subtle gradient to simulate gloss
-  let sphereCenterX = width / 2;
-  let sphereCenterY = height / 2;
-  let sphereRadius = min(width, height) * 0.4;
+    // Sphere with a subtle gradient to simulate gloss
+    let sphereCenterX = p.width / 2;
+    let sphereCenterY = p.height / 2;
+    let sphereRadius = p.min(p.width, p.height) * 0.4;
 
-  for (let i = 0; i < sphereRadius; i++) {
-    let lightness = map(i, 0, sphereRadius, 255, 220); // Gradient effect
-    fill(lightness);
-    noStroke();
-    ellipse(sphereCenterX, sphereCenterY, sphereRadius * 2 - i * 2, sphereRadius * 2 - i * 2);
-  }
+    for (let i = 0; i < sphereRadius; i++) {
+      let lightness = p.map(i, 0, sphereRadius, 255, 220); // Gradient effect
+      p.fill(lightness);
+      p.noStroke();
+      p.ellipse(sphereCenterX, sphereCenterY, sphereRadius * 2 - i * 2, sphereRadius * 2 - i * 2);
+    }
 
-  // Particle system simulating ink flow
-  for (let i = 0; i < particles.length; i++) {
-    particles[i].update();
-    particles[i].show();
-  }
+    // Particle system simulating ink flow
+    for (let i = 0; i < particles.length; i++) {
+      particles[i].update();
+      particles[i].show();
+    }
 
-  // Remove dead particles
-  for (let i = particles.length - 1; i >= 0; i--) {
-    if (particles[i].finished()) {
-      particles.splice(i, 1);
+    // Remove dead particles
+    for (let i = particles.length - 1; i >= 0; i--) {
+      if (particles[i].finished()) {
+        particles.splice(i, 1);
+      }
+    }
+  };
+
+  p.mouseMoved = () => {
+    // Emit particles near the mouse position
+    for (let i = 0; i < 5; i++) { // Adjust number of particles emitted
+      let particle = new Particle(p.mouseX + p.random(-10, 10), p.mouseY + p.random(-10, 10));
+      particles.push(particle);
+    }
+  };
+
+  // Particle class
+  class Particle {
+    constructor(x, y) {
+      this.x = x;
+      this.y = y;
+      this.vx = p.random(-1, 1); // Initial X velocity
+      this.vy = p.random(-1, 1); // Initial Y velocity
+      this.alpha = 255; // Opacity
+      this.size = p.random(2, 5);
+    }
+
+    update() {
+      this.x += this.vx;
+      this.y += this.vy;
+      this.alpha -= 2; // Fade out
+    }
+
+    finished() {
+      return this.alpha < 0;
+    }
+
+    show() {
+      p.noStroke();
+      p.fill(0, this.alpha); // Black with opacity
+      p.ellipse(this.x, this.y, this.size);
     }
   }
-}
-
-function mouseMoved() {
-  // Emit particles near the mouse position
-  for (let i = 0; i < 5; i++) { // Adjust number of particles emitted
-    let p = new Particle(mouseX + random(-10, 10), mouseY + random(-10, 10));
-    particles.push(p);
-  }
-}
-
-// Particle class
-class Particle {
-  constructor(x, y) {
-    this.x = x;
-    this.y = y;
-    this.vx = random(-1, 1); // Initial X velocity
-    this.vy = random(-1, 1); // Initial Y velocity
-    this.alpha = 255; // Opacity
-    this.size = random(2, 5);
-  }
-
-  update() {
-    this.x += this.vx;
-    this.y += this.vy;
-    this.alpha -= 2; // Fade out
-  }
-
-  finished() {
-    return this.alpha < 0;
-  }
-
-  show() {
-    noStroke();
-    fill(0, this.alpha); // Black with opacity
-    ellipse(this.x, this.y, this.size);
-  }
-}
+};
+new p5(sketch2);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Three.js Canvases</title>
+    <style>
+        body { margin: 0; }
+        #canvas-container { display: flex; }
+        canvas { width: 50vw; height: 100vh; display: block; } /* Adjusted for side-by-side full height */
+    </style>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.9.0/p5.js"></script>
+</head>
+<body>
+    <div id="canvas-container">
+        <canvas id="canvas1"></canvas>
+        <canvas id="canvas2"></canvas>
+    </div>
+    <script async src="https://unpkg.com/es-module-shims@1.6.3/dist/es-module-shims.js"></script>
+    <script src="canvas1.js"></script>
+    <script src="canvas2.js"></script>
+</body>
+</html>

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const cors = require('cors');
+const path = require('path'); // Add path module
 
 const app = express();
 const port = 3000;
@@ -7,8 +8,12 @@ const port = 3000;
 // Enable CORS for all routes
 app.use(cors());
 
+// Serve static files from the current directory
+app.use(express.static(__dirname));
+
+// Send index.html for the root route
 app.get('/', (req, res) => {
-  res.send('Hello World!');
+  res.sendFile(path.join(__dirname, 'index.html'));
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
- Creates an `index.html` to display two canvases side-by-side.
- Includes p5.js library and modifies `canvas1.js` and `canvas2.js` to use p5.js instance mode, rendering into the specified canvas elements.
- Updates the Express server (`index.js`) to serve `index.html` at the root route and provide static file serving.
- Styles `index.html` for side-by-side canvas display.
- Updates `README.md` with instructions to view the new page.